### PR TITLE
Added new AMI ids for different regions

### DIFF
--- a/elastic/wazuh_cf_elastic.sh
+++ b/elastic/wazuh_cf_elastic.sh
@@ -139,7 +139,7 @@ yum -y install logstash-${elastic_version}
 echo "Installed logstash." >> /tmp/log
 
 #Wazuh configuration for Logstash
-curl -so /etc/logstash/conf.d/01-wazuh.conf "https://raw.githubusercontent.com/wazuh/wazuh/3.9/extensions/logstash/6.x/01-wazuh-remote.conf"
+curl -so /etc/logstash/conf.d/01-wazuh.conf "https://raw.githubusercontent.com/wazuh/wazuh/v3.9.0/extensions/logstash/01-wazuh-remote.conf"
 sed -i "s/localhost:9200/${eth0_ip}:9200/" /etc/logstash/conf.d/01-wazuh.conf
 
 # Creating data and logs directories

--- a/elastic/wazuh_cf_elastic.sh
+++ b/elastic/wazuh_cf_elastic.sh
@@ -139,7 +139,7 @@ yum -y install logstash-${elastic_version}
 echo "Installed logstash." >> /tmp/log
 
 #Wazuh configuration for Logstash
-curl -so /etc/logstash/conf.d/01-wazuh.conf "https://raw.githubusercontent.com/wazuh/wazuh/3.9/extensions/logstash/01-wazuh-remote.conf"
+curl -so /etc/logstash/conf.d/01-wazuh.conf "https://raw.githubusercontent.com/wazuh/wazuh/3.9/extensions/logstash/6.x/01-wazuh-remote.conf"
 sed -i "s/localhost:9200/${eth0_ip}:9200/" /etc/logstash/conf.d/01-wazuh.conf
 
 # Creating data and logs directories

--- a/elastic/wazuh_cf_kibana.sh
+++ b/elastic/wazuh_cf_kibana.sh
@@ -128,7 +128,7 @@ sleep 60
 echo "Started service." >> /tmp/log
 
 # Loading and tuning Wazuh alerts template
-url_alerts_template="https://raw.githubusercontent.com/wazuh/wazuh/3.9/extensions/elasticsearch/wazuh-elastic6-template-alerts.json"
+url_alerts_template="https://raw.githubusercontent.com/wazuh/wazuh/v3.9.0/extensions/elasticsearch/wazuh-elastic6-template-alerts.json"
 alerts_template="/tmp/wazuh-elastic6-template-alerts.json"
 curl -Lo ${alerts_template} ${url_alerts_template}
 curl -XPUT "http://${eth0_ip}:9200/_template/wazuh" -H 'Content-Type: application/json' -d@${alerts_template}

--- a/wazuh/cluster/wazuh_cf_master.sh
+++ b/wazuh/cluster/wazuh_cf_master.sh
@@ -95,7 +95,7 @@ wget https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/alienvaul
 wget https://wazuh.com/resources/iplist-to-cdblist.py -O /var/ossec/etc/lists/iplist-to-cdblist.py
 # Add Windows public IP to the list
 echo ${WindowsPublicIp} >> /var/ossec/etc/lists/alienvault_reputation.ipset
-python /var/ossec/etc/lists/iplist-to-cdblist.py /var/ossec/etc/lists/alienvault_reputation.ipset /var/ossec/etc/lists/blacklist-alienvault
+python /var/ossec/etc/lists/iplist-to-cdblist.py /var/ossec/etc/lists/alienvault_reputation.ipset /var/ossec/etc/lists/blacklist-alienvault.cdb
 
 # Delete ipset and python script
 rm -rf /var/ossec/etc/lists/alienvault_reputation.ipset
@@ -424,7 +424,7 @@ chkconfig --add filebeat
 echo "Installed Filebeat." >> /tmp/log
 
 # Configuring Filebeat
-curl -so /etc/filebeat/filebeat.yml https://raw.githubusercontent.com/wazuh/wazuh/3.9/extensions/filebeat/filebeat.yml
+curl -so /etc/filebeat/filebeat.yml https://raw.githubusercontent.com/wazuh/wazuh/v3.9.0/extensions/filebeat/filebeat.yml
 sed -i "s/YOUR_ELASTIC_SERVER_IP/${elb_logstash}/" /etc/filebeat/filebeat.yml
 service filebeat restart
 echo "Restarted Filebeat." >> /tmp/log

--- a/wazuh/cluster/wazuh_cf_worker.sh
+++ b/wazuh/cluster/wazuh_cf_worker.sh
@@ -318,7 +318,7 @@ chkconfig --add filebeat
 echo "Installed Filebeat" >> /tmp/log
 
 # Configuring Filebeat
-curl -so /etc/filebeat/filebeat.yml https://raw.githubusercontent.com/wazuh/wazuh/3.9/extensions/filebeat/filebeat.yml
+curl -so /etc/filebeat/filebeat.yml https://raw.githubusercontent.com/wazuh/wazuh/v3.9.0/extensions/filebeat/filebeat.yml
 sed -i "s/YOUR_ELASTIC_SERVER_IP/${elb_logstash}/" /etc/filebeat/filebeat.yml
 service filebeat start
 echo "Started Filebeat" >> /tmp/log

--- a/wazuh_template.yml
+++ b/wazuh_template.yml
@@ -3,40 +3,105 @@ AWSTemplateFormatVersion: 2010-09-09
 Mappings:
   RegionMap:
     us-east-1:
-      HVM64: ami-0ff8a91507f77f867
+      HVM64: ami-0c6b1d09930fac512
+      HVMCENTOS7: ami-02eac2c0129f6376b
+      HVMUBUNTU64: ami-024a64a6685d05041
+      HVMREDHAT7: ami-6871a115
+      HVMDEBIAN: ami-0357081a1383dc76b
+      HVMWINDOWS: ami-0a9ca0496f746e6e0
+
     us-east-2:
-      HVM64: ami-0b59bfac6be064b78
+      HVM64: ami-0ebbf2179e615c338
+      HVMCENTOS7: ami-0f2b4fc905b0bd1f1
+      HVMUBUNTU64: ami-097ebb39620d8d54b
+      HVMREDHAT7: ami-03291866
+      HVMDEBIAN: ami-09c10a66337c79669
+      HVMWINDOWS: ami-0087a83ed4a60d1e9
+
     us-west-1:
-      HVM64: ami-0019ef04ac50be30f
-      HVMUBUNTU64: ami-06397100adf427136
+      HVM64: ami-015954d5e5548d13b
+      HVMUBUNTU64: ami-040dfc3ebf1bfc4f6
       HVMCENTOS7: ami-074e2d6769f445be5
       HVMREDHAT7: ami-18726478
-      HVMDEBIAN: ami-0343ae47
-      HVMWINDOWS: ami-0231dfcfb04c8de06
+      HVMDEBIAN: ami-0adbaf2e0ce044437
+      HVMWINDOWS: ami-004a782f694e8dde2
     us-west-2:
-      HVM64: ami-a0cfeed8
+      HVM64: ami-0cb72367e98845d43
+      HVMUBUNTU64: ami-0196ce5c34425a906
+      HVMCENTOS7: ami-01ed306a12b7d1c96
+      HVMREDHAT7: ami-28e07e50
+      HVMDEBIAN: ami-05a3ef6744aa96514
+      HVMWINDOWS: ami-0a7f9ce0459523133
     ca-central-1:
-      HVM64: ami-0b18956f
-    eu-central-1:
-      HVM64: ami-0233214e13e500f77
+      HVM64: ami-08a9b721ecc5b0a53
+      HVMUBUNTU64: ami-0380eb76ff3ad603f
+      HVMCENTOS7: ami-033e6106180a626d0
+      HVMREDHAT7: ami-49f0762d
+      HVMDEBIAN: ami-04413a263a7d94982
+      HVMWINDOWS: ami-020e569ea1f3a4e1c
     eu-west-1:
-      HVM64: ami-047bb4163c506cd98
+      HVM64: ami-030dbca661d402413
+      HVMUBUNTU64: ami-0b2a4d260c54e8d3d
+      HVMCENTOS7: ami-0ff760d16d9497662
+      HVMREDHAT7: ami-7c491f05
+      HVMDEBIAN: ami-0968f6a31fc6cffc0
+      HVMWINDOWS: ami-03838ccd5cfb84782
     eu-west-2:
-      HVM64: ami-f976839e
+      HVM64: ami-0009a33f033d8b7b6
+      HVMUBUNTU64: ami-09dd110e91f421069
+      HVMCENTOS7: ami-0eab3a90fc693af19
+      HVMREDHAT7: ami-7c1bfd1b
+      HVMDEBIAN: ami-0faa9c9b5399088fd
+      HVMWINDOWS: ami-0ebf422d2a92724ec
     eu-west-3:
-      HVM64: ami-0ebc281c20e89ba4b
+      HVM64: ami-0ebb3a801d5fb8b9b
+      HVMUBUNTU64: ami-00e557eb4a269bf1c
+      HVMCENTOS7: ami-0e1ab783dc9489f34
+      HVMREDHAT7: ami-5026902d
+      HVMDEBIAN: ami-0cd23820af84edc85
+      HVMWINDOWS: ami-022cfeccb4b72d6b8
     ap-northeast-1:
-      HVM64: ami-06cd52961ce9f0d85
+      HVM64: ami-00d101850e971728d
+      HVMUBUNTU64: ami-0b5a5c971fc30e5d1
+      HVMCENTOS7: ami-045f38c93733dd48d
+      HVMREDHAT7: ami-6b0d5f0d
+      HVMDEBIAN: ami-09fbcd30452841cb9
+      HVMWINDOWS: ami-02192102f14f0a10a
     ap-northeast-2:
-      HVM64: ami-0a10b2721688ce9d2
+      HVM64: ami-08ab3f7e72215fe91
+      HVMUBUNTU64: ami-06af4ace0697354bf
+      HVMCENTOS7: ami-06cf2a72dadf92410
+      HVMREDHAT7: ami-3eee4150
+      HVMDEBIAN: ami-08363ccce96df1fff
+      HVMWINDOWS: ami-0708a3b845edea89c
     ap-southeast-1:
-      HVM64: ami-08569b978cc4dfa10
+      HVM64: ami-0b5a47f8865280111
+      HVMUBUNTU64: ami-0355471dc9f264631
+      HVMCENTOS7: ami-0b4dd9d65556cac22
+      HVMREDHAT7: ami-76144b0a
+      HVMDEBIAN: ami-0555b1a5444087dd4
+      HVMWINDOWS: ami-0afce41e503676765
     ap-southeast-2:
-      HVM64: ami-09b42976632b27e9b
+      HVM64: ami-0fb7513bcdc525c3b
+      HVMUBUNTU64: ami-0065540df76a93885
+      HVMCENTOS7: ami-08bd00d7713a39e7d
+      HVMREDHAT7: ami-67589505
+      HVMDEBIAN: ami-029c54f988446691a
+      HVMWINDOWS: ami-0628ef1f10e34307d
     ap-south-1:
-      HVM64: ami-0912f71e06545ad88
+      HVM64: ami-00e782930f1c3dbc7
+      HVMUBUNTU64: ami-076b389b9989430c2
+      HVMCENTOS7: ami-02e60be79e78fef21
+      HVMREDHAT7: ami-5b673c34
+      HVMDEBIAN: ami-0dc98cbb0d0e49162
+      HVMWINDOWS: ami-0e719217acb64308e
     sa-east-1:
-      HVM64: ami-07b14488da8ea02a0
+      HVM64: ami-058141e091292ecf0
+      HVMUBUNTU64: ami-009e4c831385f8901
+      HVMCENTOS7: ami-0b8d86d4bf91850af
+      HVMREDHAT7: ami-b0b7e3dc
+      HVMDEBIAN: ami-030580e61468e54bd
+      HVMWINDOWS: ami-07df12f3c5005cd1f
   SubnetConfig:
     WazuhVpc:
       CIDR: 10.0.0.0/16
@@ -1537,11 +1602,6 @@ Resources:
       InstanceType: !Ref DebianInstanceType
       IamInstanceProfile: !Ref InstanceProfile
       KeyName: !Ref KeyPairName
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: 200
-            VolumeType: gp2
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref DebianEth0
           DeviceIndex: 0


### PR DESCRIPTION
Hi team,

This PR implements #3 , it adds new AMI ids for the following regions:

- us-east-1
- us-east-2
- us-west-1
- us-west-2
- ca-central-1
- eu-west-1
- eu-west-2
- eu-west-3
- ap-northeast-1
- ap-northeast-2
- ap-southeast-1
- ap-southeast-2
- ap-south-1

Regards
