### PR TITLE
Use parameter to set CIDR for SSH ingress

### DIFF
--- a/production/wazuh_template.yml
+++ b/production/wazuh_template.yml
@@ -87,8 +87,9 @@ Metadata:
           - KibanaPort
       -
         Label:
-          default: "SSL Certificate"
+          default: "Security"
         Parameters:
+          - SSHAccessCidr
           - SSLCertificateARN
 
 Parameters:
@@ -267,6 +268,13 @@ Parameters:
     Default: '443'
     Description: Port for Kibana WUI
     Type: String
+
+  # Security
+  SSHAccessCidr:
+    Description: A CIDR from which SSH access to the instances is allowed
+    AllowedPattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
+    ConstraintDescription: Parameter should be a CIDR block e.g. "1.2.3.4/32"
+    Type: String
   SSLCertificateARN:
     Description: 'Used for HTTPS access to WUI. Existent certificate, identified by its Amazon Resource Name (ARN).'
     Type: String
@@ -372,7 +380,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: 0.0.0.0/0
+          CidrIp: !Ref SSHAccessCidr
         - IpProtocol: tcp
           FromPort: 9200
           ToPort: 9400
@@ -392,7 +400,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: 0.0.0.0/0
+          CidrIp: !Ref SSHAccessCidr
         - IpProtocol: tcp
           FromPort: !Ref KibanaPort
           ToPort: !Ref KibanaPort
@@ -416,7 +424,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: 0.0.0.0/0
+          CidrIp: !Ref SSHAccessCidr
         - IpProtocol: tcp
           FromPort: 3389
           ToPort: 3389


### PR DESCRIPTION
Hi team 👋 reading through the template and wanted to offer this PR for consideration.

I would like to be able to pass in the CIDR of my office / VPN to determine where the security group will allow SSH traffic from. 😊

[AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html#add-rule-authorize-access) recommends limiting access to common administrative ports to only a specific IP address or range of addresses.

[AWS Trusted Advisor](https://www.amazonaws.cn/en/support/trustedadvisor/best-practices/) will also create a high-risk finding under Security if these ports are open in the Security Groups:

> Unrestricted access increases opportunities for malicious activity (hacking, denial-of-service attacks, loss of data). The ports with highest risk are flagged red, and those with less risk are flagged yellow. Ports flagged green are typically used by applications that require unrestricted access, such as HTTP and SMTP.
