### PR TITLE
Removing EIP and TLS from production template

### DIFF
--- a/production/wazuh_template.yml
+++ b/production/wazuh_template.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Provides production ready environment with a Wazuh cluster of two nodes, Elasticsearch cluster of three nodes with xpack security and SSL enabled.
+Description: Provides production ready environment with a Wazuh cluster of two nodes and Elasticsearch cluster of three nodes with xpack security.
 Mappings:
   RegionMap:
     us-east-1:
@@ -90,7 +90,6 @@ Metadata:
           default: "Security"
         Parameters:
           - SSHAccessCidr
-          - SSLCertificateARN
 
 Parameters:
 
@@ -276,12 +275,8 @@ Parameters:
     AllowedPattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
     ConstraintDescription: Parameter should be a CIDR block e.g. "1.2.3.4/32"
     Type: String
-  SSLCertificateARN:
-    Description: 'Used for HTTPS access to WUI. Existent certificate, identified by its Amazon Resource Name (ARN).'
-    Type: String
 
 Conditions:
-  HasSslCert: !Not [!Equals [!Ref SSLCertificateARN, ""]]
   EnableDNSRecords: !Not [!Equals [!Ref EnableDNSRecord, "disabled"]]
 
 Resources:
@@ -550,20 +545,6 @@ Resources:
     Properties:
       SubnetId: !Ref SubnetElasticsearch
       GroupSet: [!Ref 'ElasticSecurityGroup']
-  ElasticBootstrapEIP:
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: Name
-          Value: !Sub 'ElasticBootstrapEIP-${AWS::StackName}'
-  ElasticBootstrapEIPAssociation:
-    Type: 'AWS::EC2::EIPAssociation'
-    Properties:
-      NetworkInterfaceId: !Ref ElasticBootstrapEth0
-      AllocationId: !GetAtt
-        - ElasticBootstrapEIP
-        - AllocationId
 
   ElasticMasterB:
     Type: AWS::EC2::Instance
@@ -629,20 +610,6 @@ Resources:
     Properties:
       SubnetId: !Ref SubnetElasticsearch
       GroupSet: [!Ref 'ElasticSecurityGroup']
-  ElasticMasterBEIP:
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: Name
-          Value: !Sub 'ElasticMasterBEIP-${AWS::StackName}'
-  ElasticMasterBEIPAssociation:
-    Type: 'AWS::EC2::EIPAssociation'
-    Properties:
-      NetworkInterfaceId: !Ref ElasticMasterBEth0
-      AllocationId: !GetAtt
-        - ElasticMasterBEIP
-        - AllocationId
 
   ElasticMasterC:
     Type: AWS::EC2::Instance
@@ -708,20 +675,6 @@ Resources:
     Properties:
       SubnetId: !Ref SubnetElasticsearch
       GroupSet: [!Ref 'ElasticSecurityGroup']
-  ElasticMasterCEIP:
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: Name
-          Value: !Sub 'ElasticMasterCEIP-${AWS::StackName}'
-  ElasticMasterCEIPAssociation:
-    Type: 'AWS::EC2::EIPAssociation'
-    Properties:
-      NetworkInterfaceId: !Ref ElasticMasterCEth0
-      AllocationId: !GetAtt
-        - ElasticMasterCEIP
-        - AllocationId
 
   # Wazuh Network Load Balancer
   WazuhNetworkLoadBalancer:
@@ -830,7 +783,6 @@ Resources:
   # TLS Target Group for Network Load Balancer
   TLSTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Condition: HasSslCert
     Properties:
       Name: !Sub '${AWS::StackName}-TLSTargetGroup'
       Port: !Ref KibanaPort
@@ -891,16 +843,14 @@ Resources:
   # Listener for Kibana WUI
   TLSListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
-    Condition: HasSslCert
     Properties:
       DefaultActions:
       - Type: forward
         TargetGroupArn: !Ref TLSTargetGroup
       LoadBalancerArn: !Ref WazuhNetworkLoadBalancer
       Port: !Ref KibanaPort
-      Protocol: TLS
-      Certificates:
-      - CertificateArn: !Ref SSLCertificateARN
+      Protocol: TCP
+
 
   # IAM role and profile
   InstanceRole:
@@ -1002,20 +952,6 @@ Resources:
     Properties:
       SubnetId: !Ref SubnetElasticsearch
       GroupSet: [!Ref 'KibanaSecurityGroup']
-  KibanaEIP:
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: Name
-          Value: !Sub 'KibanaEIP-${AWS::StackName}'
-  KibanaEIPAssociation:
-    Type: 'AWS::EC2::EIPAssociation'
-    Properties:
-      NetworkInterfaceId: !Ref KibanaEth0
-      AllocationId: !GetAtt
-        - KibanaEIP
-        - AllocationId
 
   # Wazuh master instance
   WazuhMasterInstance:
@@ -1088,20 +1024,6 @@ Resources:
     Properties:
       SubnetId: !Ref SubnetWazuh
       GroupSet: [!Ref 'WazuhSecurityGroup']
-  WazuhMasterEIP:
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: Name
-          Value: !Sub 'MasterEIP-${AWS::StackName}'
-  WazuhMasterEIPAssociation:
-    Type: 'AWS::EC2::EIPAssociation'
-    Properties:
-      NetworkInterfaceId: !Ref WazuhMasterEth0
-      AllocationId: !GetAtt
-        - WazuhMasterEIP
-        - AllocationId
 
   # Wazuh worker instance
   WazuhWorkerInstance:
@@ -1150,8 +1072,12 @@ Resources:
             VolumeSize: 50
             VolumeType: gp2
       NetworkInterfaces:
-        - NetworkInterfaceId: !Ref WazuhWorkerEth0
-          DeviceIndex: 0
+        - AssociatePublicIpAddress: "true"
+          DeviceIndex: "0"
+          GroupSet:
+            - Ref: "WazuhSecurityGroup"
+          SubnetId:
+            Ref: "SubnetWazuh"
       Tags:
         - Key: Name
           Value: WazuhWorker
@@ -1166,20 +1092,7 @@ Resources:
     Properties:
       SubnetId: !Ref SubnetWazuh
       GroupSet: [!Ref 'WazuhSecurityGroup']
-  WazuhWorkerEIP:
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: Name
-          Value: !Sub 'WorkerEIP-${AWS::StackName}'
-  WazuhWorkerEIPAssociation:
-    Type: 'AWS::EC2::EIPAssociation'
-    Properties:
-      NetworkInterfaceId: !Ref WazuhWorkerEth0
-      AllocationId: !GetAtt
-        - WazuhWorkerEIP
-        - AllocationId
+
 Outputs:
   ElasticBootstrapIp:
     Description: Elastic Bootstrap IP


### PR DESCRIPTION
### Work in progress, do not merge!
Hi team,

This PR removes EIP and TLS from the production template. Further changes will be needed as after disabling the TLS the Wazuh WUI can't be accessed correctly through https.

Greetings,
JP