### PR TITLE
Use `POST` method when requesting the API login endpoint

### DIFF
--- a/production/wazuh/cluster/wazuh_cf_master.sh
+++ b/production/wazuh/cluster/wazuh_cf_master.sh
@@ -189,13 +189,13 @@ echo "Restarted Wazuh manager." >> /tmp/deploy.log
 
 # get token
 
-TOKEN=$(curl -u wazuh:wazuh -k -X GET "https://localhost:55000/security/user/authenticate?raw=true")
+TOKEN=$(curl -u wazuh:wazuh -k -X POST "https://localhost:55000/security/user/authenticate?raw=true")
 
 # Change default password
 curl -k -X PUT "https://localhost:55000/security/users/1" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"password":"'"$ssh_password"'"}'
 
 # get new token
-TOKEN=$(curl -u wazuh:$ssh_password -k -X GET "https://localhost:55000/security/user/authenticate?raw=true")
+TOKEN=$(curl -u wazuh:$ssh_password -k -X POST "https://localhost:55000/security/user/authenticate?raw=true")
 
 # Installing Filebeat
 yum -y install filebeat-${elastic_version}


### PR DESCRIPTION
This PR closes https://github.com/wazuh/wazuh-cloudformation/issues/97.

In this pull request, I have changed the method used when requesting the API login endpoint from GET to POST because as it was said in the related issue, the actual login endpoint (GET) is going to be deprecated.